### PR TITLE
Implement Error for ParseError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,16 +70,7 @@ impl From<io::Error> for ParseError {
     }
 }
 
-impl Error for ParseError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            ParseError::IncludeSubdomainsInvalid(err) => Some(err),
-            ParseError::SecureInvalid(err) => Some(err),
-            ParseError::ExpiresInvalid(err) => Some(err),
-            _ => None,
-        }
-    }
-}
+impl Error for ParseError {}
 
 pub fn parse(bytes: &[u8]) -> Result<Vec<Cookie>, ParseError> {
     let mut cursor = Cursor::new(bytes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fmt;
 use std::io::{self, BufRead, Cursor};
 use std::num::ParseIntError;
@@ -66,6 +67,17 @@ impl fmt::Display for ParseError {
 impl From<io::Error> for ParseError {
     fn from(err: io::Error) -> Self {
         Self::IoError((err.kind(), err.to_string()))
+    }
+}
+
+impl Error for ParseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ParseError::IncludeSubdomainsInvalid(err) => Some(err),
+            ParseError::SecureInvalid(err) => Some(err),
+            ParseError::ExpiresInvalid(err) => Some(err),
+            _ => None,
+        }
     }
 }
 


### PR DESCRIPTION
I'm using this crate and I find ParseError not work with [`anyhow::Result<T>`](https://docs.rs/anyhow/1.0.38/anyhow/type.Result.html) because it does not implenent `std::error::Error`. And I think there is no negetive effects to do so since `ParseError` represents an error and doing this can support sorts of error handling libraries.

I'm also wondering why not directly store `io::Error` in `ParseError::IoError` as well as return `Result<(), ParseError>` in `test_parse_demo()`. By the way, the test is failing.

I'm sorry for my poor English.